### PR TITLE
Fix matrix-to-map conversion bug

### DIFF
--- a/apolo2matriz.m
+++ b/apolo2matriz.m
@@ -1,13 +1,23 @@
 function [fila, columna] = apolo2matriz(x_apolo, y_apolo)
-    if x_apolo < 0 || x_apolo > 10 || y_apolo < 0 || y_apolo > 33
+    % Conversión de coordenadas del sistema Apolo (origen abajo derecha)
+    % a índices de la matriz de ocupación (origen arriba izquierda).
+    %  - x_apolo: Coordenada vertical en metros
+    %  - y_apolo: Coordenada horizontal en metros
+    % Devuelve [fila, columna] como índices 1-based del mapa binario.
+
+    % Validar el rango de entrada. Se permiten valores dentro
+    % del tamaño del mapa excluyendo el límite superior para
+    % evitar celdas fuera de rango al convertir.
+    if x_apolo < 0 || x_apolo >= 10 || y_apolo < 0 || y_apolo >= 33
         error('Coordenadas de entrada fuera de los límites permitidos.');
     end
 
     disp(['[DEBUG] Entrando a apolo2matriz con x_apolo=', num2str(x_apolo), ', y_apolo=', num2str(y_apolo)]);
-    fila    = 10 - x_apolo;
-    columna = 33 - y_apolo;
-    fila = round(fila);
-    columna = round(columna);
+
+    % Convertir usando floor para asegurar valores dentro de los 
+    % límites de 1..10 y 1..33 respectivamente.
+    fila    = 10 - floor(x_apolo);
+    columna = 33 - floor(y_apolo);
 
     if fila < 1 || fila > 10 || columna < 1 || columna > 33
         error('Coordenadas convertidas fuera de los límites del mapa.');

--- a/matriz2apolo.m
+++ b/matriz2apolo.m
@@ -1,9 +1,20 @@
-x_apolo = 10 - fila;  % Conversión de fila a coordenada Apolo
-if x_apolo < 0 || x_apolo > 10
-    error('Coordenadas convertidas fuera de los límites del mapa.');
-end
+function [x_apolo, y_apolo] = matriz2apolo(fila, columna)
+    % Conversión inversa de coordenadas del mapa de MATLAB al sistema Apolo.
+    %  - fila:    Índice de fila en el mapa (1..10)
+    %  - columna: Índice de columna en el mapa (1..33)
+    % Devuelve las coordenadas [x_apolo, y_apolo] en metros para el simulador.
 
-y_apolo = 33 - columna; % Conversión de columna a coordenada Apolo
-if y_apolo < 0 || y_apolo > 33
-    error('Coordenadas convertidas fuera de los límites del mapa.');
-end 
+    % Validar entrada
+    if fila < 1 || fila > 10 || columna < 1 || columna > 33
+        error('Coordenadas convertidas fuera de los límites del mapa.');
+    end
+
+    % Aplicar la transformación inversa
+    x_apolo = 10 - fila;  % Conversión de fila a coordenada Apolo
+    y_apolo = 33 - columna; % Conversión de columna a coordenada Apolo
+
+    % Verificación adicional para evitar valores fuera de rango
+    if x_apolo < 0 || x_apolo > 10 || y_apolo < 0 || y_apolo > 33
+        error('Coordenadas resultantes fuera de los límites permitidos.');
+    end
+end


### PR DESCRIPTION
## Summary
- correct apolo2matriz range checks
- use floor() to avoid out-of-range conversions

## Testing
- `octave --version`
- `octave --eval "run('run_tests.m');"` *(fails: robot/world not active)*

------
https://chatgpt.com/codex/tasks/task_e_68588fc46bd483278ada454dbee72bdb